### PR TITLE
Save PR number in Test action

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -70,9 +70,9 @@ jobs:
         id: get_pr_data
         with:
           route: GET /repos/{full_name}/pulls/{number}
-          number: ${{ steps.pr_number.outputs.content }}
-          full_name: ${{ github.event.repository.full_name }}
         env:
+          INPUT_FULL_NAME: ${{ github.event.repository.full_name }}
+          INPUT_NUMBER: ${{ steps.pr_number.outputs.content }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: SonarCloud Scan (for PRs)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,15 @@ jobs:
         with:
           name: timeweaver-lcov-file
           path: coverage/lcov.info
+
+      # For SonarCloud to analyse the code from pull request
+      - name: Save PR number (for SonarCloud)
+        if: github.event_name == 'pull_request'
+        run: echo ${{ github.event.number }} > PR_NUMBER.txt
+
+      - name: Upload PR number to GitHub Artifacts (for SonarCloud)
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: PR_NUMBER
+          path: PR_NUMBER.txt


### PR DESCRIPTION
This addresses #20.

Previously, the PR number was not saved to Artifacts in the build step, so SonarCloud pull request analysis fails