### PR TITLE
Logic for multiple groups and styling changes

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1,7 +1,6 @@
 body {
   display: flex;
   flex-direction: column;
-  /* height: 100%; */
 }
 
 .border-left-none {
@@ -25,19 +24,22 @@ body {
   background-color: white;
 }
 
-#sidebar-toggle {
-  width: 150px;
-}
-
 #dynamic-tabs {
+  margin-bottom: 0px !important;
   position: sticky;
   top: 0px;
   z-index: 100;
 }
 
 #page-container {
-  width: 100%;
+  display: flex;
+  flex-direction: row;
   height: 100%;
+}
+
+#content-container {
+  transform: none !important;
+  margin-top: 15px;
 }
 
 .active {

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -46,7 +46,6 @@ body {
  * Group sidebar and items
  */
 .group-item-container {
-  /* min-height: 71px; */
   padding: 16px 8px 16px 8px !important;
   width: 100%;
   display: flex !important;

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -42,6 +42,37 @@ body {
   margin-top: 15px;
 }
 
-.active {
-  background-color: #e6e6e6;
+.group-item-container {
+  /* min-height: 71px; */
+  padding: 16px 8px 16px 8px !important;
+  width: 100%;
+  display: flex !important;
+  flex-direction: row !important;
+  gap: 5px;
+  justify-content: start;
+  align-items: center;
+}
+
+.group-selected {
+  background-color: #3d3e3f !important;
+  color: white !important;
+}
+
+.group-content-container {
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 5px;
+  flex-grow: 1;
+}
+
+.group-content-container > span {
+  overflow-wrap: break-word;
+  max-width: 100%;
+}
+
+.group-content-container > .icon {
+  margin-right: 0px !important;
 }

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1,3 +1,9 @@
+body {
+  display: flex;
+  flex-direction: column;
+  /* height: 100%; */
+}
+
 .border-left-none {
   border-left: hidden !important;
 }
@@ -21,4 +27,19 @@
 
 #sidebar-toggle {
   width: 150px;
+}
+
+#dynamic-tabs {
+  position: sticky;
+  top: 0px;
+  z-index: 100;
+}
+
+#page-container {
+  width: 100%;
+  height: 100%;
+}
+
+.active {
+  background-color: #e6e6e6;
 }

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -42,6 +42,9 @@ body {
   margin-top: 15px;
 }
 
+/** 
+ * Group sidebar and items
+ */
 .group-item-container {
   /* min-height: 71px; */
   padding: 16px 8px 16px 8px !important;

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
   </head>
 
   <body>
-    <div class="ui huge menu" id="dynamicTabs">
+    <div class="ui huge menu" id="dynamic-tabs">
       <div class="header item">
         <i class="calendar check icon"></i>
         <span>TimeWeaver</span>
@@ -39,7 +39,7 @@
     <button id="sidebar-toggle" class="ui huge button">
       <span id="group-name">No Groups</span>
     </button>
-    <div id="content-body" class="ui">
+    <div id="page-container" class="ui container">
       <!-- Sidebar from https://fomantic-ui.com/modules/sidebar.html#/definition-->
       <div
         id="sidebar"

--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,6 @@
       <div
         id="sidebar"
         class="ui left inverted vertical menu labeled icon thin sidebar visible"
-        style="position: sticky"
       >
         <a id="add-group-modal-open" class="item">
           <i class="plus icon"></i>

--- a/public/index.html
+++ b/public/index.html
@@ -43,14 +43,14 @@
       <!-- Sidebar from https://fomantic-ui.com/modules/sidebar.html#/definition-->
       <div
         id="sidebar"
-        class="ui left vertical inverted labeled icon thin sidebar menu overlay"
+        class="ui left inverted vertical menu labeled icon thin sidebar"
       >
         <a id="add-group-modal-open" class="item">
           <i class="plus icon"></i>
           <span>Add Group</span>
         </a>
       </div>
-      <div class="ui container">
+      <div class="ui container pusher">
         <table
           id="calendar-display-table"
           class="ui celled table border-left-none align center"

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,6 @@
 
         <span>Add Person</span></a
       >
-
       <div class="right menu backgroundColour">
         <div class="ui purple item">
           <a id="view-combination-button"
@@ -33,24 +32,26 @@
         </div>
       </div>
     </div>
-    <div id="page-content" class="ui container">
-      <h1 id="calendar-title" class="calendarTitle">No Calendar Selected</h1>
-    </div>
-    <button id="sidebar-toggle" class="ui huge button">
-      <span id="group-name">No Groups</span>
-    </button>
-    <div id="page-container" class="ui container">
+
+    <div id="page-container" class="ui container fluid pushable">
       <!-- Sidebar from https://fomantic-ui.com/modules/sidebar.html#/definition-->
       <div
         id="sidebar"
-        class="ui left inverted vertical menu labeled icon thin sidebar"
+        class="ui left inverted vertical menu labeled icon thin sidebar visible"
+        style="position: sticky"
       >
         <a id="add-group-modal-open" class="item">
           <i class="plus icon"></i>
           <span>Add Group</span>
         </a>
       </div>
-      <div class="ui container pusher">
+      <div id="content-container" class="ui container pusher">
+        <div id="page-content">
+          <h1 id="calendar-title" class="calendarTitle">
+            No Calendar Selected
+          </h1>
+        </div>
+
         <table
           id="calendar-display-table"
           class="ui celled table border-left-none align center"

--- a/src/constants/strings.js
+++ b/src/constants/strings.js
@@ -1,0 +1,5 @@
+const NO_CALENDAR_SELECTED = "No Calendar Selected";
+
+module.exports = {
+  NO_CALENDAR_SELECTED,
+};

--- a/src/manageCalendars.js
+++ b/src/manageCalendars.js
@@ -11,9 +11,11 @@ const title = document.getElementById("calendar-title");
 const icalName = document.getElementById("ical-name-input");
 const icalInput = document.getElementById("ical-link-input");
 const manualName = document.getElementById("manual-name-input");
-const dynamicSection = document.getElementById("dynamicTabs");
+const dynamicSection = document.getElementById("dynamic-tabs");
 
-const NON_DYNAMIC_NAV_ELEMENTS = 3;
+// When hiding and showing different modals, Fomantic uses a 500ms animation. This delay is
+// used to ensure that the animation is not interrupted, which can cause rendering issues.
+const MODAL_HIDE_SHOW_DELAY = 0;
 
 /** Mapping buttons to their onClick functions */
 document
@@ -59,16 +61,27 @@ function resetCalendar() {
 
 function addCalendar() {
   formatModal.modal("show");
+  $(".dimmable").css("margin-right", "0px");
 }
 
 function uploadIcal() {
   formatModal.modal("hide");
-  addIcalModal.modal("show");
+  // $(".dimmable").css("margin-right", "0px");
+
+  setTimeout(() => {
+    addIcalModal.modal("show");
+    // $(".dimmable").css("margin-right", "0px");
+  }, MODAL_HIDE_SHOW_DELAY);
 }
 
 function uploadManual() {
+  // $(".dimmable").css("margin-right", "0px");
   formatModal.modal("hide");
-  addManualModal.modal("show");
+  setTimeout(() => {
+    addManualModal.modal("show");
+    // $(".dimmable").css("margin-right", "0px");
+  }, MODAL_HIDE_SHOW_DELAY);
+
   initializeCellListeners();
 }
 

--- a/src/manageCalendars.js
+++ b/src/manageCalendars.js
@@ -2,6 +2,7 @@ const { urlToJSON } = require("./icalToJSON");
 const converter = require("./converter");
 const onDisplay = require("./onDisplay");
 const combine = require("./combine");
+const { NO_CALENDAR_SELECTED } = require("./constants/strings");
 const { selectCurrentWeek } = require("./selectCurrentWeek");
 const { addManualModal, addIcalModal, formatModal } = require("./modals");
 
@@ -46,6 +47,14 @@ function openCalendar(name) {
   const [userInfo] = calList.filter((x) => x.user === name);
 
   onDisplay(userInfo.calendarJson, 1);
+}
+
+/**
+ * Shows an empty calendar
+ */
+function resetCalendar() {
+  title.textContent = NO_CALENDAR_SELECTED;
+  onDisplay(JSON.stringify({ cells: [] }), 0);
 }
 
 function addCalendar() {
@@ -94,7 +103,7 @@ async function setupNewIcal() {
 
   const userJson = converter(
     JSON.stringify({ events: formatted }),
-    icalName.value
+    icalName.value,
   );
 
   const info = {
@@ -142,19 +151,22 @@ function setupNewManual() {
 
 /** Updates the Top Navigation based on the current Calendar List */
 function updateCalList() {
+  // Remove all the calendar items
+  for (child of dynamicSection.children) {
+    if (child.classList.contains("calendar-select")) {
+      child.remove();
+    }
+  }
+
   const referenceNode = dynamicSection.children[1];
 
-  // Repeats for However many items in the calList are not already represented as navigation tabs
-  for (
-    let i = dynamicSection.children.length - NON_DYNAMIC_NAV_ELEMENTS;
-    i < calList.length;
-    i++
-  ) {
+  // Creates new entry for each calendar in the top navigation
+  for (let i = 0; i < calList.length; i++) {
     const title = document.createElement("span");
     title.innerHTML = calList[i].user;
 
     const link = document.createElement("a");
-    link.setAttribute("class", "item");
+    link.setAttribute("class", "calendar-select item");
     link.appendChild(title);
     link.addEventListener("click", function () {
       openCalendar(calList[i].user);
@@ -195,12 +207,22 @@ function setCell(cell) {
   if (cell.classList.contains("cellSelected")) {
     cell.classList.remove("cellSelected");
     cell.style.backgroundColor = null;
-    cellList = cellList.filter((x) => x != id); // Convolutted way of removing the cell from the cellList array
+    cellList = cellList.filter((x) => x != id); // Convoluted way of removing the cell from the cellList array
   } else {
     cell.classList.add("cellSelected");
     cell.style.backgroundColor = "purple";
     cellList.push(id);
   }
+}
+
+/**
+ * Updates the calendar list and triggers refresh
+ *
+ * @param {Array} newCalList
+ */
+function setCalList(newCalList) {
+  calList = newCalList;
+  updateCalList();
 }
 
 module.exports = {
@@ -215,5 +237,7 @@ module.exports = {
   calList,
   cellList,
   setCell,
+  setCalList,
+  resetCalendar,
   initializeCellListeners,
 };

--- a/src/manageCalendars.js
+++ b/src/manageCalendars.js
@@ -33,7 +33,9 @@ document
   .addEventListener("click", setupNewManual);
 document
   .getElementById("setup-new-calendar-ical")
-  .addEventListener("click", setupNewIcal);
+  .addEventListener("click", () => {
+    setupNewIcal();
+  });
 
 /** List of Uploaded Calendars */
 let calList = [];
@@ -66,20 +68,15 @@ function addCalendar() {
 
 function uploadIcal() {
   formatModal.modal("hide");
-  // $(".dimmable").css("margin-right", "0px");
-
   setTimeout(() => {
     addIcalModal.modal("show");
-    // $(".dimmable").css("margin-right", "0px");
   }, MODAL_HIDE_SHOW_DELAY);
 }
 
 function uploadManual() {
-  // $(".dimmable").css("margin-right", "0px");
   formatModal.modal("hide");
   setTimeout(() => {
     addManualModal.modal("show");
-    // $(".dimmable").css("margin-right", "0px");
   }, MODAL_HIDE_SHOW_DELAY);
 
   initializeCellListeners();

--- a/src/manageCalendars.js
+++ b/src/manageCalendars.js
@@ -152,15 +152,11 @@ function setupNewManual() {
 /** Updates the Top Navigation based on the current Calendar List */
 function updateCalList() {
   // Remove all the calendar items
-  for (child of dynamicSection.children) {
-    if (child.classList.contains("calendar-select")) {
-      child.remove();
-    }
-  }
+  $(dynamicSection).children(".calendar-select").remove();
 
   const referenceNode = dynamicSection.children[1];
 
-  // Creates new entry for each calendar in the top navigation
+  // Creates new entry in the top navigation for each calendar
   for (let i = 0; i < calList.length; i++) {
     const title = document.createElement("span");
     title.innerHTML = calList[i].user;

--- a/src/manageCalendars.js
+++ b/src/manageCalendars.js
@@ -13,10 +13,6 @@ const icalInput = document.getElementById("ical-link-input");
 const manualName = document.getElementById("manual-name-input");
 const dynamicSection = document.getElementById("dynamic-tabs");
 
-// When hiding and showing different modals, Fomantic uses a 500ms animation. This delay is
-// used to ensure that the animation is not interrupted, which can cause rendering issues.
-const MODAL_HIDE_SHOW_DELAY = 0;
-
 /** Mapping buttons to their onClick functions */
 document
   .getElementById("add-calendar-modal-open")
@@ -68,17 +64,12 @@ function addCalendar() {
 
 function uploadIcal() {
   formatModal.modal("hide");
-  setTimeout(() => {
-    addIcalModal.modal("show");
-  }, MODAL_HIDE_SHOW_DELAY);
+  addIcalModal.modal("show");
 }
 
 function uploadManual() {
   formatModal.modal("hide");
-  setTimeout(() => {
-    addManualModal.modal("show");
-  }, MODAL_HIDE_SHOW_DELAY);
-
+  addManualModal.modal("show");
   initializeCellListeners();
 }
 

--- a/src/manageGroups.js
+++ b/src/manageGroups.js
@@ -46,6 +46,8 @@ function openGroup(name) {
   displayName.innerHTML = name;
   const selectedGroup = groupList.filter((x) => x.name === name)[0];
 
+  setCalList(selectedGroup.calendarList);
+
   if (selectedGroup.calendarList.length === 0) {
     resetCalendar();
   } else {

--- a/src/manageGroups.js
+++ b/src/manageGroups.js
@@ -12,7 +12,7 @@ const groupName = document.getElementById("group-name-input");
 
 // Set sidebar parent context
 $(".ui.labeled.icon.sidebar").sidebar({
-  context: $("#content-body"),
+  context: $("#page-container"),
 });
 
 const NON_DYNAMIC_SIDEBAR_ELEMENTS = 1;
@@ -30,6 +30,7 @@ document
 
 /** List of Uploaded Groups */
 let groupList = [];
+let selectedGroup;
 
 /** Toggles visibility of groups sidebar */
 function showGroupsSidebar() {
@@ -44,6 +45,7 @@ function showGroupsSidebar() {
 /** Handles the Display of the Group When Sidebar Element is Clicked */
 function openGroup(name) {
   displayName.innerHTML = name;
+
   const selectedGroup = groupList.filter((x) => x.name === name)[0];
 
   setCalList(selectedGroup.calendarList);
@@ -94,9 +96,25 @@ function updateGroupList() {
     link.setAttribute("class", "item");
     link.appendChild(icon);
     link.appendChild(name);
-    link.addEventListener("click", function () {
+    link.addEventListener("click", function (event) {
+      event.target.classList.add("active");
+      if (selectedGroup) {
+        selectedGroup.classList.remove("active");
+      }
+      selectedGroup = event.target;
+
       openGroup(groupList[i].name);
     });
+
+    // Only trigger the parent click event when the child is clicked
+    $(link)
+      .children()
+      .click(function (e) {
+        const event = new Event("click");
+        link.dispatchEvent(event);
+
+        e.stopPropagation();
+      });
 
     name.innerHTML = groupList[i].name;
 

--- a/src/manageGroups.js
+++ b/src/manageGroups.js
@@ -10,6 +10,11 @@ const displayName = document.getElementById("group-name");
 const sidebar = document.getElementById("sidebar");
 const groupName = document.getElementById("group-name-input");
 
+// Set sidebar parent context
+$(".ui.labeled.icon.sidebar").sidebar({
+  context: $("#content-body"),
+});
+
 const NON_DYNAMIC_SIDEBAR_ELEMENTS = 1;
 
 /** Mapping buttons to their onClick functions */
@@ -28,13 +33,12 @@ let groupList = [];
 
 /** Toggles visibility of groups sidebar */
 function showGroupsSidebar() {
-  $(".ui.labeled.icon.sidebar")
-    .sidebar({
-      context: $("#content-body"),
-      dimPage: false,
-    })
-    .sidebar("setting", "transition", "overlay")
-    .sidebar("toggle");
+  $(".ui.labeled.icon.sidebar").sidebar("setting", {
+    dimPage: false,
+    transition: "overlay",
+  });
+
+  $(".ui.labeled.icon.sidebar").sidebar("toggle");
 }
 
 /** Handles the Display of the Group When Sidebar Element is Clicked */

--- a/src/manageGroups.js
+++ b/src/manageGroups.js
@@ -21,13 +21,22 @@ const NON_DYNAMIC_SIDEBAR_ELEMENTS = 1;
 document
   .getElementById("add-group-modal-open")
   .addEventListener("click", addGroup);
-document
-  .getElementById("setup-new-group")
-  .addEventListener("click", setupNewGroup);
+document.getElementById("setup-new-group").addEventListener("click", () => {
+  addGroupModal.modal("hide");
+
+  setupNewGroup(groupName.value);
+
+  groupName.value = "";
+});
 
 /** List of Uploaded Groups */
 let groupList = [];
 let selectedGroup;
+
+// Add and select initial group
+setupNewGroup("Default");
+selectedGroup = sidebar.children[0];
+selectedGroup.classList.add("disabled", "group-selected");
 
 /** Handles the Display of the Group When Sidebar Element is Clicked */
 function openGroup(name) {
@@ -48,19 +57,13 @@ function addGroup() {
 }
 
 /** Handles setup of a new Group */
-function setupNewGroup() {
-  if (
-    groupName.value !== "" &&
-    !groupList.some((x) => x.name === groupName.value)
-  ) {
-    addGroupModal.modal("hide");
-
+function setupNewGroup(name) {
+  if (name !== "" && !groupList.some((x) => x.name === name)) {
     groupList.push({
-      name: groupName.value,
+      name: name,
       groupUrl: "",
       calendarList: [],
     });
-    groupName.value = "";
 
     updateGroupList();
   }
@@ -106,9 +109,9 @@ function createGroupElement(groupName) {
 
   $(groupIcon).addClass("user friends icon");
 
-  groupNameSpan.innerHTML = groupName;
+  $(groupNameSpan).html(groupName);
 
-  groupSelectLink.addEventListener("click", () => {
+  $(groupSelectLink).click(() => {
     if (selectedGroup === groupSelectLink) {
       return;
     }

--- a/src/manageGroups.js
+++ b/src/manageGroups.js
@@ -17,7 +17,6 @@ $(".ui.labeled.icon.sidebar").sidebar({
 const NON_DYNAMIC_SIDEBAR_ELEMENTS = 1;
 
 /** Mapping buttons to their onClick functions */
-
 document
   .getElementById("add-group-modal-open")
   .addEventListener("click", addGroup);
@@ -127,6 +126,7 @@ function createGroupElement(groupName) {
   });
 
   $(trashButton).click(function (e) {
+    // Don't trigger the parent click event
     e.stopPropagation();
 
     // Don't allow deletion of the currently selected group

--- a/src/manageGroups.js
+++ b/src/manageGroups.js
@@ -1,4 +1,9 @@
 const { addGroupModal } = require("./modals");
+const {
+  setCalList,
+  resetCalendar,
+  openCalendar,
+} = require("./manageCalendars.js");
 
 /** HTML Element Declarations */
 const displayName = document.getElementById("group-name");
@@ -8,7 +13,9 @@ const groupName = document.getElementById("group-name-input");
 const NON_DYNAMIC_SIDEBAR_ELEMENTS = 1;
 
 /** Mapping buttons to their onClick functions */
-document.getElementById("sidebar-toggle").addEventListener("click", showGroups);
+document
+  .getElementById("sidebar-toggle")
+  .addEventListener("click", showGroupsSidebar);
 document
   .getElementById("add-group-modal-open")
   .addEventListener("click", addGroup);
@@ -20,7 +27,7 @@ document
 let groupList = [];
 
 /** Toggles visibility of groups sidebar */
-function showGroups() {
+function showGroupsSidebar() {
   $(".ui.labeled.icon.sidebar")
     .sidebar({
       context: $("#content-body"),
@@ -33,6 +40,13 @@ function showGroups() {
 /** Handles the Display of the Group When Sidebar Element is Clicked */
 function openGroup(name) {
   displayName.innerHTML = name;
+  const selectedGroup = groupList.filter((x) => x.name === name)[0];
+
+  if (selectedGroup.calendarList.length === 0) {
+    resetCalendar();
+  } else {
+    openCalendar(selectedGroup.calendarList[0].user);
+  }
 }
 
 /** Handles creation of a new Group by the user */
@@ -49,7 +63,7 @@ function setupNewGroup() {
   groupList.push({
     name: groupName.value,
     groupUrl: "",
-    //groupJson: JSON.stringify({  }),
+    calendarList: [],
   });
   groupName.value = "";
 
@@ -66,12 +80,11 @@ function updateGroupList() {
     i < groupList.length;
     i++
   ) {
-    const name = document.createElement("span");
-    name.innerHTML = groupList[i].name;
-    const icon = document.createElement("i");
-    icon.setAttribute("class", "user friends icon");
-
+    // Creates new entry in sidebar
     const link = document.createElement("a");
+    const name = document.createElement("span");
+    const icon = document.createElement("i");
+
     link.setAttribute("class", "item");
     link.appendChild(icon);
     link.appendChild(name);
@@ -79,12 +92,16 @@ function updateGroupList() {
       openGroup(groupList[i].name);
     });
 
+    name.innerHTML = groupList[i].name;
+
+    icon.setAttribute("class", "user friends icon");
+
     sidebar.insertBefore(link, referenceNode);
   }
 }
 
 module.exports = {
-  showGroups,
+  showGroups: showGroupsSidebar,
   addGroup,
   setupNewGroup,
 };

--- a/src/manageGroups.js
+++ b/src/manageGroups.js
@@ -6,7 +6,6 @@ const {
 } = require("./manageCalendars.js");
 
 /** HTML Element Declarations */
-const displayName = document.getElementById("group-name");
 const sidebar = document.getElementById("sidebar");
 const groupName = document.getElementById("group-name-input");
 
@@ -18,9 +17,7 @@ $(".ui.labeled.icon.sidebar").sidebar({
 const NON_DYNAMIC_SIDEBAR_ELEMENTS = 1;
 
 /** Mapping buttons to their onClick functions */
-document
-  .getElementById("sidebar-toggle")
-  .addEventListener("click", showGroupsSidebar);
+
 document
   .getElementById("add-group-modal-open")
   .addEventListener("click", addGroup);
@@ -31,16 +28,6 @@ document
 /** List of Uploaded Groups */
 let groupList = [];
 let selectedGroup;
-
-/** Toggles visibility of groups sidebar */
-function showGroupsSidebar() {
-  $(".ui.labeled.icon.sidebar").sidebar("setting", {
-    dimPage: false,
-    transition: "overlay",
-  });
-
-  $(".ui.labeled.icon.sidebar").sidebar("toggle");
-}
 
 /** Handles the Display of the Group When Sidebar Element is Clicked */
 function openGroup(name) {
@@ -125,7 +112,6 @@ function updateGroupList() {
 }
 
 module.exports = {
-  showGroups: showGroupsSidebar,
   addGroup,
   setupNewGroup,
 };


### PR DESCRIPTION
Work done towards #37 

- Groups sidebar is always showing and no longer needs to toggle
- Groups can be removed (provided the group is not selected)
- Groups can be selected and calendars can be added separately to each group
- Removes vertical scrollbar from application