### PR TITLE
Duplicate group name deletion fix

### DIFF
--- a/src/schemas/calendar.js
+++ b/src/schemas/calendar.js
@@ -1,5 +1,27 @@
 const { z } = require("zod");
 
+/**
+ * @typedef {Object} CalendarCell
+ * @property {string} id - The id of the cell
+ * @property {string[]} users - The list of users who are available at this time
+ * @property {number} numPeople - The number of people who are available at this time
+ */
+
+/**
+ * @typedef {Object} Calendar
+ * @property {string} groupId - The id of the group this calendar belongs to
+ * @property {string} user - The name of the user who owns this calendar
+ * @property {string} icalUrl - The url of the ical file
+ * @property {string} calendarJson - The json string of the calendar
+ */
+
+/**
+ * @typedef {Object} CalendarGroup
+ * @property {string} id - The id of the group
+ * @property {string} name - The name of the group
+ * @property {Calendar[]} calendarList - The list of calendars in this group
+ */
+
 /* Stores information regarding the calendar table cells */
 const calendarCellSchema = z
   .object({

--- a/src/store/CalendarStore.js
+++ b/src/store/CalendarStore.js
@@ -4,19 +4,32 @@ const {
   groupListEntityConverter,
   selectedSlotDBConverter,
 } = require("../helpers/entity_mapping/calendarMapping.js");
+const { CalendarGroup } = require("../schemas/calendar");
 
 class CalendarStore {
   static _instance;
-  /* The currently selected calendar */
+  /**
+   * The currently selected calendar list
+   * @type {Calendar[]}
+   */
   selectedCalList = [];
 
-  /* The currently selected group */
+  /**
+   * The ID of the currently selected group
+   * @type {string}
+   */
   selectedGroup;
 
-  /* The currently selected group HTML element in sidebar */
+  /**
+   * The currently selected group HTML element in sidebar
+   * @type {HTMLElement}
+   */
   selectedGroupElem;
 
-  /* List of all groups and its associated calendars */
+  /**
+   * List of all groups and its associated calendars
+   * @type {CalendarGroup[]}
+   */
   groupList = [];
 
   /**

--- a/src/views/manageAccount.js
+++ b/src/views/manageAccount.js
@@ -100,7 +100,6 @@ function userSignup() {
     })
     .then((data) => {
       // Make a POST request to enter user information into the databasea
-      console.log(data);
       const sendData = {
         id: data.user.id,
         name: document.getElementById("signup-name-input").value,
@@ -162,10 +161,10 @@ function handleLogin() {
       .then((data) => {
         // Update info on the my account modal
         document.getElementById(
-          "name-info"
+          "name-info",
         ).textContent = ` ${data.user.user_metadata.name}`;
         document.getElementById(
-          "email-info"
+          "email-info",
         ).textContent = ` ${data.user.email}`;
       });
   }


### PR DESCRIPTION
Fixes #92 

It may make sense for calendar groups to have the same name. It is insensible to make calendar group name globally unique, as different users may want to create groups with the same name (e.g. users may create a 'Group Meeting' group).

When a user belongs to groups with the same name, there is a bug with deleting them detailed in #92. This PR should fix it.